### PR TITLE
Fix compatibility with Spring Boot 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ to asynchronous tasks.
 
 The following properties may be set in your application.properties file to override default values.
 ```properties
-threadScope.poolSize=25
-threadScope.threadNamePrefix=async-
-threadScope.scopeName=request
+thread-scope.pool-size=25
+thread-scope.thread-name-prefix=async-
+thread-scope.scope-name=request
 ```
 
 The default setting of `threadScope.scopeName=request` will replace the default web request scope with the starter's

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.2.3.RELEASE</version>
+        <version>1.5.9.RELEASE</version>
     </parent>
 
     <properties>

--- a/src/main/java/devbury/threadscope/ThreadScopeConfiguration.java
+++ b/src/main/java/devbury/threadscope/ThreadScopeConfiguration.java
@@ -29,7 +29,7 @@ import org.springframework.core.env.ConfigurableEnvironment;
 @Import(SchedulerConfiguration.class)
 public class ThreadScopeConfiguration {
 
-    public static final String SCOPE_NAME_PROPERTY = "threadScope.scopeName";
+    public static final String SCOPE_NAME_PROPERTY = "thread-scope.scope-name";
 
     private static final Logger logger = LoggerFactory.getLogger(ThreadScopeConfiguration.class);
 

--- a/src/main/java/devbury/threadscope/ThreadScopeProperties.java
+++ b/src/main/java/devbury/threadscope/ThreadScopeProperties.java
@@ -18,7 +18,7 @@ package devbury.threadscope;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-@ConfigurationProperties(prefix = "threadScope")
+@ConfigurationProperties(prefix = "thread-scope")
 public class ThreadScopeProperties {
 
     public static final String DEFAULT_SCOPE_NAME = "request";

--- a/src/test/java/devbury/threadscope/IntegrationTest.java
+++ b/src/test/java/devbury/threadscope/IntegrationTest.java
@@ -21,25 +21,22 @@ import org.junit.runner.RunWith;
 import org.springframework.aop.interceptor.SimpleAsyncUncaughtExceptionHandler;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.test.SpringApplicationConfiguration;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Scope;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
-import org.springframework.web.context.WebApplicationContext;
 
 import static org.junit.Assert.assertEquals;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration(classes = IntegrationTest.class)
+@SpringBootTest(classes = {IntegrationTest.class, ValueBeanProvider.class})
 @WebAppConfiguration
 @EnableAutoConfiguration
 public class IntegrationTest {
 
     @Autowired
-    ValueBean valueBean;
+    ValueBeanProvider.ValueBean valueBean;
 
     @Autowired
     TaskExecutor taskExecutor;
@@ -72,23 +69,5 @@ public class IntegrationTest {
         });
         Thread.sleep(100);
         assertEquals("TWO", valueBean.getValue());
-    }
-
-    @Bean
-    @Scope(WebApplicationContext.SCOPE_REQUEST)
-    public ValueBean valueBean() {
-        return new ValueBean();
-    }
-
-    public class ValueBean {
-        private String value;
-
-        public String getValue() {
-            return value;
-        }
-
-        public void setValue(String value) {
-            this.value = value;
-        }
     }
 }

--- a/src/test/java/devbury/threadscope/ValueBeanProvider.java
+++ b/src/test/java/devbury/threadscope/ValueBeanProvider.java
@@ -1,0 +1,28 @@
+package devbury.threadscope;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
+import org.springframework.web.context.WebApplicationContext;
+
+@Configuration
+public class ValueBeanProvider {
+
+    @Bean
+    @Scope(WebApplicationContext.SCOPE_REQUEST)
+    public ValueBean valueBean() {
+        return new ValueBean();
+    }
+
+    public class ValueBean {
+        private String value;
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+}

--- a/src/test/java/devbury/threadscope/integration/ServletRequestListenerTest.java
+++ b/src/test/java/devbury/threadscope/integration/ServletRequestListenerTest.java
@@ -16,50 +16,33 @@
 
 package devbury.threadscope.integration;
 
-import devbury.threadscope.ThreadScopeManager;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.test.SpringApplicationConfiguration;
-import org.springframework.boot.test.TestRestTemplate;
-import org.springframework.boot.test.WebIntegrationTest;
-import org.springframework.context.annotation.Bean;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-
-import javax.servlet.ServletRequestEvent;
 
 import static org.junit.Assert.assertTrue;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration(classes = {ServletRequestListenerTest.class})
-@WebIntegrationTest("server.port:0")
+@SpringBootTest(classes = {ServletRequestListenerTest.class, ThreadScopeManagerProvider.class}, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableAutoConfiguration
 @ComponentScan
 public class ServletRequestListenerTest {
 
     static boolean requestDestroyedCalled = false;
 
-    @Value("${local.server.port}")
-    int port;
+    @Autowired
+    private TestRestTemplate testRestTemplate;
 
     @Test
     public void verifyServletRequestListenerRegisteredAndCalled() throws Exception {
-        TestRestTemplate restTemplate = new TestRestTemplate();
-        restTemplate.getForObject("http://localhost:{port}/test", String.class, port);
+        testRestTemplate.getForObject("/test", String.class);
         assertTrue(requestDestroyedCalled);
     }
 
-    @Bean
-    public ThreadScopeManager threadScopeManager() {
-        return new ThreadScopeManager() {
-            @Override
-            public void requestDestroyed(ServletRequestEvent servletRequestEvent) {
-                requestDestroyedCalled = true;
-                super.requestDestroyed(servletRequestEvent);
-            }
-        };
-    }
 }
 

--- a/src/test/java/devbury/threadscope/integration/ThreadScopeManagerProvider.java
+++ b/src/test/java/devbury/threadscope/integration/ThreadScopeManagerProvider.java
@@ -1,0 +1,27 @@
+package devbury.threadscope.integration;
+
+import devbury.threadscope.ThreadScopeManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.servlet.ServletRequestEvent;
+
+@Configuration
+class ThreadScopeManagerProvider {
+
+    @Autowired
+    public ThreadScopeManagerProvider() {
+    }
+
+    @Bean
+    public ThreadScopeManager threadScopeManager() {
+        return new ThreadScopeManager() {
+            @Override
+            public void requestDestroyed(ServletRequestEvent servletRequestEvent) {
+                ServletRequestListenerTest.requestDestroyedCalled = true;
+                super.requestDestroyed(servletRequestEvent);
+            }
+        };
+    }
+}


### PR DESCRIPTION
Since Spring Boot 2.0  it is required to use properties in "kebab-case" format. Therefore an application using your plugin won't start after upgrading to the latest Spring Boot version (see https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.0-Migration-Guide#type-safe-configuration-properties).
This PR fixes that problem and also upgrades all tests to the latest Spring Boot 1.5.9 API. The new version works in both my Spring Boot 1.x and 2.x projects.
Please provide also a new version on maven central if you decide to accept this PR.